### PR TITLE
SingleNfts from each collection saved to dataStore

### DIFF
--- a/FakeNFT/Helpers/CustomViews/Buttons/CustomHeartButton.swift
+++ b/FakeNFT/Helpers/CustomViews/Buttons/CustomHeartButton.swift
@@ -24,9 +24,11 @@ extension CustomHeartButton {
     func setAppearance(for appearance: Appearance) {
         switch appearance {
         case .favourite:
-            setImage(UIImage(systemName: K.Icons.heart)?.withTintColor(.universalRed), for: .normal)
+//            setImage(UIImage(systemName: K.Icons.heart)?.withTintColor(.universalRed), for: .normal)
+            setImage(UIImage(systemName: K.Icons.heart)?.withTintColor(.universalRed, renderingMode: .alwaysOriginal), for: .normal)
         case .normal:
-            setImage(UIImage(systemName: K.Icons.heart)?.withTintColor(.universalWhite), for: .normal)
+//            setImage(UIImage(systemName: K.Icons.heart)?.withTintColor(.universalWhite), for: .normal)
+            setImage(UIImage(systemName: K.Icons.heart)?.withTintColor(.universalWhite, renderingMode: .alwaysOriginal), for: .normal)
         }
         
     }

--- a/FakeNFT/Modules/CartModule/Screens/CartMainScreen/View/CartViewController.swift
+++ b/FakeNFT/Modules/CartModule/Screens/CartMainScreen/View/CartViewController.swift
@@ -103,7 +103,7 @@ final class CartViewController: UIViewController {
     }()
     
     private var diffableDataSource: CartDataSourceManagerProtocol
-    private var viewModel: CartViewModel
+    private let viewModel: CartViewModel
     
     // MARK: Init
     init(dataSource: CartDataSourceManagerProtocol, viewModel: CartViewModel) {

--- a/FakeNFT/Modules/CatalogModule/Coordinator/CatalogCoordinator.swift
+++ b/FakeNFT/Modules/CatalogModule/Coordinator/CatalogCoordinator.swift
@@ -59,7 +59,7 @@ private extension CatalogCoordinator {
     }
     
     func showCatalogCollectionScreen(with collection: NftCollection) {
-        var collectionScreen = factory.makeCatalogCollectionScreenView(with: collection, dataSource: collectionViewDataSource)
+        var collectionScreen = factory.makeCatalogCollectionScreenView(with: collection, dataSource: collectionViewDataSource, dataStore: dataStore)
         
         collectionScreen.onCancel = { [weak router] in
             router?.popToRootViewController(animated: true, completion: nil)

--- a/FakeNFT/Modules/CatalogModule/Screens/CatalogCollectionScreen/View/CatalogCollectionViewCell.swift
+++ b/FakeNFT/Modules/CatalogModule/Screens/CatalogCollectionScreen/View/CatalogCollectionViewCell.swift
@@ -13,6 +13,8 @@ final class CatalogCollectionViewCell: UICollectionViewCell, ReuseIdentifying {
     private var cancellables = Set<AnyCancellable>()
     private var id: String?
     
+    var onLike: ((String?) -> Void)?
+    
     var viewModel: CatalogCollectionCellViewModel? {
         didSet {
             viewModel?.$nftRow
@@ -70,7 +72,7 @@ final class CatalogCollectionViewCell: UICollectionViewCell, ReuseIdentifying {
     private lazy var namePriceAndButtonStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.alignment = .trailing
+        stackView.alignment = .center
         stackView.addArrangedSubview(labelsStackView)
         stackView.addArrangedSubview(addOrDeleteButton)
         return stackView
@@ -136,10 +138,21 @@ final class CatalogCollectionViewCell: UICollectionViewCell, ReuseIdentifying {
     
 }
 
+// MARK: - Ext @objc
+@objc private extension CatalogCollectionViewCell {
+    func likeTapped() {
+        onLike?(id)
+    }
+}
+
 // MARK: - Ext Constraints
 private extension CatalogCollectionViewCell {
     func setupConstraints() {
         setupMainStackView()
+        setupLabelHeights()
+        setupNftImageViewSize()
+        setupNamePriceAndButtonStackView()
+        setupHeartButton()
     }
     
     func setupMainStackView() {
@@ -152,13 +165,36 @@ private extension CatalogCollectionViewCell {
             mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+    }
+    
+    func setupLabelHeights() {
+        NSLayoutConstraint.activate([
+            nftName.heightAnchor.constraint(greaterThanOrEqualToConstant: 22),
+            nftPriceLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 12)
+        ])
+    }
+    
+    func setupNftImageViewSize() {
+        NSLayoutConstraint.activate([
+            nftImageView.heightAnchor.constraint(equalTo: nftImageView.widthAnchor)
+        ])
+    }
+    
+    func setupNamePriceAndButtonStackView() {
+        NSLayoutConstraint.activate([
+            namePriceAndButtonStackView.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+        ])
+    }
+    
+    func setupHeartButton() {
+        addSubview(heartButton)
+        heartButton.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            nftImageView.heightAnchor.constraint(equalTo: nftImageView.widthAnchor),
-            nftName.heightAnchor.constraint(greaterThanOrEqualToConstant: 22),
-            nftPriceLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 12),
-            addOrDeleteButton.trailingAnchor.constraint(equalTo: namePriceAndButtonStackView.trailingAnchor),
-            namePriceAndButtonStackView.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor)
+            heartButton.topAnchor.constraint(equalTo: mainStackView.topAnchor, constant: 10),
+            heartButton.trailingAnchor.constraint(equalTo: mainStackView.trailingAnchor, constant: -10),
+            heartButton.heightAnchor.constraint(equalToConstant: 18),
+            heartButton.widthAnchor.constraint(equalToConstant: 21)
         ])
     }
 }

--- a/FakeNFT/Modules/CatalogModule/Screens/CatalogCollectionScreen/View/CatalogCollectionViewController.swift
+++ b/FakeNFT/Modules/CatalogModule/Screens/CatalogCollectionScreen/View/CatalogCollectionViewController.swift
@@ -21,7 +21,7 @@ final class CatalogCollectionViewController: UIViewController & CatalogCollectio
     var cancellables = Set<AnyCancellable>()
     
     private let viewModel: CatalogCollectionViewModel
-    private let diffableDataSource: NftCollectionDSManagerProtocol
+    private var diffableDataSource: NftCollectionDSManagerProtocol
     
     private lazy var flowLayout: UICollectionViewFlowLayout = {
         let layout = UICollectionViewFlowLayout()
@@ -167,6 +167,9 @@ private extension CatalogCollectionViewController {
     
     func createCollectionView() {
         diffableDataSource.createDataSource(with: collectionView, with: viewModel.visibleNfts)
+        diffableDataSource.onLikeHandler = { [weak self] id in
+            
+        }
     }
     
     func updateUI(with collection: NftCollection) {

--- a/FakeNFT/Modules/CatalogModule/Screens/CatalogCollectionScreen/ViewModel/CatalogCollectionViewModel.swift
+++ b/FakeNFT/Modules/CatalogModule/Screens/CatalogCollectionScreen/ViewModel/CatalogCollectionViewModel.swift
@@ -12,25 +12,68 @@ final class CatalogCollectionViewModel {
     @Published private (set) var nftCollection: NftCollection
     @Published private (set) var visibleNfts: [SingleNft] = []
     
+    private var cancellables = Set<AnyCancellable>()
+    
     private let networkClient: NetworkClient
+    private let dataStore: CatalogDataStorageProtocol
         
-    init(nftCollection: NftCollection, networkClient: NetworkClient) {
+    init(nftCollection: NftCollection, networkClient: NetworkClient, dataStore: CatalogDataStorageProtocol) {
         self.nftCollection = nftCollection
         self.networkClient = networkClient
+        self.dataStore = dataStore
+        
+        bind()
     }
     
     func updateNfts(from collection: NftCollection) {
+        let storedCollectionNfts = dataStore.getCatalogNfts(from: collection)
+        
+        storedCollectionNfts.isEmpty || storedCollectionNfts.count != collection.nfts.count ?
+        load(collection: collection) : (self.visibleNfts = storedCollectionNfts)
+        
+        
+    }
+    
+    func load(collection: NftCollection) {
         collection.nfts.forEach { [weak self] id in
             let request = RequestConstructor.constructNftCollectionRequest(method: .get, collectionId: id)
             self?.networkClient.send(request: request, type: SingleNft.self) { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case .success(let nft):
-                    self.visibleNfts.append(nft)
+                    self.sendNftToStorage(nft: nft)
                 case .failure(_):
+                    // TODO: make a mock error element
                     print("Failure")
                 }
             }
         }
+    }
+    
+    func updateLikeImage(with id: String) {
+        
+    }
+    
+    func sendNftToStorage(nft: SingleNft) {
+        dataStore.addNftRowItem(nft)
+    }
+}
+
+private extension CatalogCollectionViewModel{
+    func bind() {
+        dataStore.catalogNftCollectionDataPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] nfts in
+                self?.showNeededNfts(from: nfts)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func showNeededNfts(from nfts: [SingleNft]) {
+        let visibleNfts = nfts.filter { nft in
+            nftCollection.nfts.contains(where: { $0 == nft.id })
+        }
+        
+        self.visibleNfts = visibleNfts
     }
 }

--- a/FakeNFT/Navigation/Factories/ModulesFactory.swift
+++ b/FakeNFT/Navigation/Factories/ModulesFactory.swift
@@ -11,7 +11,8 @@ protocol CatalogModuleFactoryProtocol {
     func makeCatalogScreenView(dataSource: CatalogDataSourceManagerProtocol,
                                dataStore: CatalogDataStorageProtocol) -> Presentable & CatalogMainScreenCoordinatable
     func makeCatalogCollectionScreenView(with collection: NftCollection,
-                                         dataSource: NftCollectionDSManagerProtocol) -> Presentable & CatalogCollectionCoordinatable
+                                         dataSource: NftCollectionDSManagerProtocol,
+                                         dataStore: CatalogDataStorageProtocol) -> Presentable & CatalogCollectionCoordinatable
 }
 
 protocol CartModuleFactoryProtocol {
@@ -34,9 +35,9 @@ extension ModulesFactory: CatalogModuleFactoryProtocol {
         return CatalogViewController(dataSource: dataSource, viewModel: viewModel)
     }
     
-    func makeCatalogCollectionScreenView(with collection: NftCollection, dataSource: NftCollectionDSManagerProtocol) -> Presentable & CatalogCollectionCoordinatable {
+    func makeCatalogCollectionScreenView(with collection: NftCollection, dataSource: NftCollectionDSManagerProtocol, dataStore: CatalogDataStorageProtocol) -> Presentable & CatalogCollectionCoordinatable {
         let networkClient = DefaultNetworkClient()
-        let viewModel = CatalogCollectionViewModel(nftCollection: collection, networkClient: networkClient)
+        let viewModel = CatalogCollectionViewModel(nftCollection: collection, networkClient: networkClient, dataStore: dataStore)
         let viewController = CatalogCollectionViewController(viewModel: viewModel, diffableDataSource: dataSource)
         return viewController
     }


### PR DESCRIPTION
after collection pickUp catalogCollectionViewModel checks if there are stored items in dataStore with equal ids. If there's no data - viewModel commands newtworkClient to load them SingleNfts stored object changed to Set<SingleNfts> in order to avoid data duplication.